### PR TITLE
feat: 사용자/관리자 역할 기반 퀴즈 기능 및 UI 분리

### DIFF
--- a/SoftwareEngineering/frontend/src/components/Header.js
+++ b/SoftwareEngineering/frontend/src/components/Header.js
@@ -8,6 +8,12 @@ const Header = () => {
   const location = useLocation();
   const isHome = location.pathname === '/';
 
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    navigate('/login');
+  };
+
   const buttonStyle = {
     padding: '0.5rem 1rem',
     borderRadius: '8px',
@@ -31,7 +37,7 @@ const Header = () => {
       boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
       marginBottom: '1rem'
     }}>
-      {/* 왼쪽 */}
+      {/* 왼쪽: 뒤로가기 + 홈 버튼 */}
       <div style={{ display: 'flex', gap: '10px' }}>
         {!isHome && (
           <button
@@ -53,8 +59,8 @@ const Header = () => {
         </button>
       </div>
 
-      {/* 오른쪽 */}
-      <div>
+      {/* 오른쪽: 마이페이지 + 로그아웃 버튼 */}
+      <div style={{ display: 'flex', gap: '10px' }}>
         <button
           style={buttonStyle}
           onClick={() => navigate('/mypage')}
@@ -62,6 +68,15 @@ const Header = () => {
           onMouseOut={e => e.target.style.background = '#f8f9fa'}
         >
           마이페이지
+        </button>
+
+        <button
+          style={{ ...buttonStyle, background: '#ffe6e6' }}
+          onClick={handleLogout}
+          onMouseOver={e => e.target.style.background = '#ffc9c9'}
+          onMouseOut={e => e.target.style.background = '#ffe6e6'}
+        >
+          🚪 로그아웃
         </button>
       </div>
     </div>

--- a/SoftwareEngineering/frontend/src/components/MainPage.js
+++ b/SoftwareEngineering/frontend/src/components/MainPage.js
@@ -36,19 +36,23 @@ const MainPage = ({ user, onLogout }) => {
 
       {/* 메뉴 버튼 */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '15px', marginTop: '1rem' }}>
-        <button
-          onClick={() => navigate('/quiz-start')}
-          style={{
-            padding: '0.8rem',
-            borderRadius: '8px',
-            border: '1px solid #ddd',
-            background: '#f8f9fa',
-            cursor: 'pointer',
-            fontSize: '1.1rem'
-          }}
-        >
-          🧠 퀴즈 시작하기
-        </button>
+
+        {/* ✅ 사용자 전용 메뉴 */}
+        {user?.role === 'user' && (
+          <button
+            onClick={() => navigate('/quiz-start')}
+            style={{
+              padding: '0.8rem',
+              borderRadius: '8px',
+              border: '1px solid #ddd',
+              background: '#f8f9fa',
+              cursor: 'pointer',
+              fontSize: '1.1rem'
+            }}
+          >
+            🧠 퀴즈 시작하기
+          </button>
+        )}
 
         <button
           onClick={() => navigate('/wordlist')}
@@ -77,7 +81,7 @@ const MainPage = ({ user, onLogout }) => {
               cursor: 'pointer',
               fontSize: '1.1rem'
             }}
-        >
+          >
             ⭐ 나만의 단어장
           </button>
         )}
@@ -99,19 +103,6 @@ const MainPage = ({ user, onLogout }) => {
           </button>
         )}
 
-        <button
-          onClick={onLogout}
-          style={{
-            padding: '0.8rem',
-            borderRadius: '8px',
-            border: '1px solid #ddd',
-            background: '#ffe6e6',
-            cursor: 'pointer',
-            fontSize: '1.1rem'
-          }}
-        >
-          🚪 로그아웃
-        </button>
       </div>
     </div>
   );

--- a/SoftwareEngineering/frontend/src/components/QuizResult.js
+++ b/SoftwareEngineering/frontend/src/components/QuizResult.js
@@ -1,12 +1,19 @@
-// src/components/QuizResult.js
-
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const QuizResult = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { score, total } = location.state || { score: 0, total: 10 };
+
+  const user = JSON.parse(localStorage.getItem('user'));
+
+  useEffect(() => {
+    if (!user || user.role !== 'user') {
+      alert('일반 사용자만 접근 가능한 기능입니다.');
+      navigate('/');
+    }
+  }, []);
 
   return (
     <div style={{
@@ -23,7 +30,6 @@ const QuizResult = () => {
         당신의 점수는 <strong style={{ color: '#51cf66' }}>{score} / {total}</strong> 입니다!
       </p>
 
-      {/* 간단한 피드백 */}
       <div style={{
         background: '#fff3bf',
         padding: '1rem',

--- a/SoftwareEngineering/frontend/src/components/QuizStart.js
+++ b/SoftwareEngineering/frontend/src/components/QuizStart.js
@@ -1,10 +1,16 @@
-// src/components/QuizStart.js
-
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const QuizStart = () => {
   const navigate = useNavigate();
+  const user = JSON.parse(localStorage.getItem('user'));
+
+  useEffect(() => {
+    if (!user || user.role !== 'user') {
+      alert('일반 사용자만 접근 가능한 기능입니다.');
+      navigate('/');
+    }
+  }, []);
 
   return (
     <div style={{
@@ -18,7 +24,7 @@ const QuizStart = () => {
     }}>
       <h2>🧠 TOEIC 뜻 고르기 퀴즈</h2>
       <p style={{ color: '#555', marginBottom: '1rem' }}>
-        총 10문제를 풀어볼 거예요!  
+        총 10문제를 풀어볼 거예요!
       </p>
       <div style={{
         background: '#e7f5ff',

--- a/SoftwareEngineering/frontend/src/components/QuizWord.js
+++ b/SoftwareEngineering/frontend/src/components/QuizWord.js
@@ -1,5 +1,3 @@
-// src/components/QuizWord.js
-
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -12,6 +10,15 @@ const QuizWord = () => {
   const [count, setCount] = useState(1);
   const [score, setScore] = useState(0);
   const navigate = useNavigate();
+
+  const user = JSON.parse(localStorage.getItem('user'));
+
+  useEffect(() => {
+    if (!user || user.role !== 'user') {
+      alert('일반 사용자만 접근 가능한 기능입니다.');
+      navigate('/');
+    }
+  }, []);
 
   const fetchQuiz = async () => {
     setResult('');
@@ -91,7 +98,6 @@ const QuizWord = () => {
 
       <p style={{ marginTop: '1rem' }}>{result}</p>
 
-      {/* ✅ 여기부터 버튼 디자인 적용 */}
       {result && (
         <div style={{ display: 'flex', gap: '10px', marginTop: '1rem' }}>
           <button
@@ -107,8 +113,6 @@ const QuizWord = () => {
               transition: '0.2s',
               boxShadow: '0 2px 5px rgba(0,0,0,0.1)'
             }}
-            onMouseOver={e => e.target.style.background = '#1c7ed6'}
-            onMouseOut={e => e.target.style.background = '#339af0'}
           >
             다음 문제 ▶
           </button>
@@ -126,8 +130,6 @@ const QuizWord = () => {
               transition: '0.2s',
               boxShadow: '0 2px 5px rgba(0,0,0,0.1)'
             }}
-            onMouseOver={e => e.target.style.background = '#37b24d'}
-            onMouseOut={e => e.target.style.background = '#51cf66'}
           >
             메인으로 돌아가기
           </button>


### PR DESCRIPTION
### 주요 변경 사항

#### 사용자/관리자 역할 기반 UI 분리
- MainPage에서 사용자만 퀴즈 및 나만의 단어장 버튼 노출
- 관리자 계정은 단어 관리 버튼만 노출되도록 조건부 렌더링 적용
- QuizStart, QuizWord, QuizResult에서 관리자 접근 시 차단 처리

#### 로그아웃 버튼 위치 변경
- MainPage에서 로그아웃 버튼 제거
- Header 우측 상단에 로그아웃 버튼 추가
- 로그아웃 시 localStorage 초기화 및 /login으로 이동

#### 기타
- user.role 조건에 따라 버튼 렌더링을 구조적으로 정리
- 코드 중복 제거 및 UI 위치 조정

---

### 관련 태그
- 릴리즈 예정 태그: `v2.1`
