### PR TITLE
feat: 관리자 단어 관리 페이지 UI 개선

### DIFF
--- a/SoftwareEngineering/frontend/src/components/AdminWordManager.js
+++ b/SoftwareEngineering/frontend/src/components/AdminWordManager.js
@@ -1,6 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+const fontStyle = {
+  fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: '1rem',
+  fontWeight: '400'
+};
+
+const headingStyle = {
+  fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: '1.5rem',
+  fontWeight: '700',
+  textAlign: 'center',
+  marginBottom: '1rem'
+};
+
 const AdminWordManager = () => {
   const [words, setWords] = useState([]);
   const [filteredWords, setFilteredWords] = useState([]);
@@ -47,7 +61,7 @@ const AdminWordManager = () => {
 
     const res = await fetch('http://localhost:5000/api/admin/words/add', {
       method: 'POST',
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
@@ -81,7 +95,7 @@ const AdminWordManager = () => {
     if (!editingWord) return;
     await fetch(`http://localhost:5000/api/admin/words/edit/${editingWord._id}`, {
       method: 'PUT',
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
@@ -93,61 +107,69 @@ const AdminWordManager = () => {
 
   const pagedWords = filteredWords.slice((page - 1) * pageSize, page * pageSize);
 
-  const buttonStyle = {
-    padding: '0.5rem 0.8rem',
-    borderRadius: '6px',
-    border: '1px solid #ccc',
-    background: '#f8f9fa',
-    cursor: 'pointer',
-    transition: '0.2s',
-    marginRight: '5px'
-  };
-
-  const primaryButtonStyle = {
-    ...buttonStyle,
-    background: '#339af0',
-    color: '#fff',
-    border: 'none'
-  };
-
   return (
-    <div style={{ padding: '2rem', maxWidth: '1000px', margin: 'auto' }}>
-      <h2>🛠️ 관리자 단어 관리</h2>
+    <div style={{
+      padding: '2rem',
+      maxWidth: '1200px',
+      margin: 'auto',
+      background: '#fff',
+      borderRadius: '12px',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+      ...fontStyle
+    }}>
+      <h2 style={headingStyle}>🛠️ 관리자 단어 관리</h2>
 
-      <div style={{ display: 'flex', gap: '10px', marginBottom: '1rem' }}>
-        <input placeholder="영어 단어" value={english} onChange={e => setEnglish(e.target.value)} style={{ flex: 1, padding: '0.7rem', borderRadius: '8px', border: '1px solid #ccc' }} />
-        <input placeholder="한글 뜻" value={korean} onChange={e => setKorean(e.target.value)} style={{ flex: 1, padding: '0.7rem', borderRadius: '8px', border: '1px solid #ccc' }} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginBottom: '1.5rem' }}>
+        <div style={{ display: 'flex', gap: '10px' }}>
+          <input placeholder="영어 단어" value={english} onChange={e => setEnglish(e.target.value)} style={{ ...fontStyle, flex: 1, padding: '0.8rem', borderRadius: '8px', border: '1px solid #ccc' }} />
+          <input placeholder="한글 뜻" value={korean} onChange={e => setKorean(e.target.value)} style={{ ...fontStyle, flex: 1, padding: '0.8rem', borderRadius: '8px', border: '1px solid #ccc' }} />
+        </div>
+        <input placeholder="예문" value={example} onChange={e => setExample(e.target.value)} style={{ ...fontStyle, padding: '0.8rem', borderRadius: '8px', border: '1px solid #ccc' }} />
+        <button onClick={handleAdd} style={{ ...fontStyle, padding: '0.6rem 1.5rem', borderRadius: '6px', background: '#339af0', color: '#fff', border: 'none', fontWeight: 'bold', width: 'fit-content', alignSelf: 'center' }}>단어 추가</button>
+        <p style={{ color: '#888', ...fontStyle }}>{message}</p>
       </div>
 
-      <input placeholder="예문" value={example} onChange={e => setExample(e.target.value)}
-        style={{ width: '100%', padding: '0.7rem', marginBottom: '1rem', borderRadius: '8px', border: '1px solid #ccc' }} />
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <input
+          type="text"
+          placeholder="🔍 단어를 검색하세요"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{
+            ...fontStyle,
+            padding: '0.8rem',
+            marginBottom: '1rem',
+            borderRadius: '8px',
+            border: '1px solid #ccc'
+          }}
+        />
+      </div>
 
-      <button onClick={handleAdd} style={primaryButtonStyle}>단어 추가</button>
-
-      <p style={{ color: '#888', marginTop: '1rem' }}>{message}</p>
-
-      <input placeholder="단어 검색 (영어/한글)" value={search} onChange={e => setSearch(e.target.value)}
-        style={{ width: '100%', padding: '0.7rem', marginBottom: '1rem', borderRadius: '8px', border: '1px solid #ccc' }} />
-
-      <div style={{ border: '1px solid #ccc', borderRadius: '8px', overflow: 'hidden' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <div style={{ border: '1px solid #ccc', borderRadius: '8px', overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'fixed', border: '1px solid #ccc', whiteSpace: 'nowrap', ...fontStyle }}>
+          <colgroup>
+            <col style={{ width: '15%' }} />
+            <col style={{ width: '15%' }} />
+            <col style={{ width: '40%' }} />
+            <col style={{ width: '8%' }} />
+          </colgroup>
           <thead style={{ background: '#f1f3f5' }}>
             <tr>
-              <th style={{ padding: '0.8rem' }}>영어</th>
-              <th>한글</th>
-              <th>예문</th>
-              <th>관리</th>
+              <th style={{ padding: '0.8rem', borderRight: '1px solid #ccc' }}>영어</th>
+              <th style={{ borderRight: '1px solid #ccc' }}>한글</th>
+              <th style={{ borderRight: '1px solid #ccc' }}>예문</th>
+              <th style={{ textAlign: 'center' }}>관리</th>
             </tr>
           </thead>
           <tbody>
             {pagedWords.map(word => (
               <tr key={word._id} style={{ borderBottom: '1px solid #eee' }}>
-                <td style={{ padding: '0.6rem' }}>{word.english}</td>
-                <td>{word.korean}</td>
-                <td>{word.example}</td>
-                <td>
-                  <button onClick={() => startEdit(word)} style={buttonStyle}>수정</button>
-                  <button onClick={() => handleDelete(word._id)} style={buttonStyle}>삭제</button>
+                <td style={{ padding: '0.6rem', borderRight: '1px solid #ccc', fontWeight: 'bold', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{word.english}</td>
+                <td style={{ borderRight: '1px solid #ccc', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{word.korean}</td>
+                <td style={{ borderRight: '1px solid #ccc', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{word.example}</td>
+                <td style={{ textAlign: 'center' }}>
+                  <button onClick={() => startEdit(word)} style={{ ...fontStyle, marginRight: '5px', padding: '0.4rem 0.7rem', borderRadius: '6px', border: '1px solid #ccc', background: '#f8f9fa' }}>수정</button>
+                  <button onClick={() => handleDelete(word._id)} style={{ ...fontStyle, padding: '0.4rem 0.7rem', borderRadius: '6px', border: '1px solid #f03e3e', background: '#fff5f5', color: '#f03e3e' }}>삭제</button>
                 </td>
               </tr>
             ))}
@@ -155,33 +177,30 @@ const AdminWordManager = () => {
         </table>
       </div>
 
-      <div style={{ marginTop: '1rem' }}>
-        페이지: {page} / {Math.ceil(filteredWords.length / pageSize)}
-        <br />
-        <button disabled={page === 1} onClick={() => setPage(page - 1)} style={buttonStyle}>이전</button>
-        <button disabled={page * pageSize >= filteredWords.length} onClick={() => setPage(page + 1)} style={buttonStyle}>다음</button>
+      <div style={{ marginTop: '1rem', textAlign: 'center', ...fontStyle }}>
+        <button disabled={page === 1} onClick={() => setPage(page - 1)} style={{ ...fontStyle, marginRight: '5px', padding: '0.5rem 1rem', borderRadius: '6px', border: '1px solid #ccc', background: '#f8f9fa' }}>이전</button>
+        <span> {page} / {Math.ceil(filteredWords.length / pageSize)} </span>
+        <button disabled={page * pageSize >= filteredWords.length} onClick={() => setPage(page + 1)} style={{ ...fontStyle, marginLeft: '5px', padding: '0.5rem 1rem', borderRadius: '6px', border: '1px solid #ccc', background: '#f8f9fa' }}>다음</button>
       </div>
 
       {editingWord && (
         <div onClick={() => setEditingWord(null)} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div onClick={e => e.stopPropagation()} style={{ background: '#fff', padding: '2rem', borderRadius: '12px', width: '400px' }}>
+          <div onClick={e => e.stopPropagation()} style={{ background: '#fff', padding: '2rem', borderRadius: '12px', width: '400px', ...fontStyle }}>
             <h3>단어 수정</h3>
-            <input value={editingWord.english} onChange={e => setEditingWord({ ...editingWord, english: e.target.value })} style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem' }} />
-            <input value={editingWord.korean} onChange={e => setEditingWord({ ...editingWord, korean: e.target.value })} style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem' }} />
-            <textarea value={editingWord.example} onChange={e => setEditingWord({ ...editingWord, example: e.target.value })} style={{ width: '100%', padding: '0.5rem', height: '80px' }} />
-            <div style={{ marginTop: '0.5rem', textAlign: 'right' }}>
-              <button onClick={handleEditSubmit} style={primaryButtonStyle}>수정 완료</button>
-              <button onClick={() => setEditingWord(null)} style={buttonStyle}>취소</button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginBottom: '1.5rem' }}>
+              <input value={editingWord.english} onChange={e => setEditingWord({ ...editingWord, english: e.target.value })} style={{ ...fontStyle, padding: '0.6rem', marginBottom: '0.5rem', borderRadius: '6px', border: '1px solid #ccc' }} />
+              <input value={editingWord.korean} onChange={e => setEditingWord({ ...editingWord, korean: e.target.value })} style={{ ...fontStyle, padding: '0.6rem', marginBottom: '0.5rem', borderRadius: '6px', border: '1px solid #ccc' }} />
+              <textarea value={editingWord.example} onChange={e => setEditingWord({ ...editingWord, example: e.target.value })} style={{ ...fontStyle, padding: '0.6rem', height: '100px', borderRadius: '6px', border: '1px solid #ccc' }} />
+              <div style={{ marginTop: '0.5rem', textAlign: 'right' }}>
+                <button onClick={handleEditSubmit} style={{ ...fontStyle, marginRight: '5px', padding: '0.5rem 1rem', borderRadius: '6px', background: '#339af0', color: '#fff', border: 'none' }}>수정 완료</button>
+                <button onClick={() => setEditingWord(null)} style={{ ...fontStyle, padding: '0.5rem 1rem', borderRadius: '6px', border: '1px solid #ccc', background: '#f8f9fa' }}>취소</button>
+              </div>
             </div>
           </div>
         </div>
       )}
-
-        <button onClick={() => navigate('/')} style={{ ...buttonStyle, marginTop: '1rem' }}>메인으로</button>
     </div>
   );
 };
 
 export default AdminWordManager;
-
-    


### PR DESCRIPTION
### 주요 변경 사항

#### 단어 추가 UI 정리
- 영어 단어 / 한글 뜻 입력창을 한 행에 나란히 배치하여 공간 활용도 향상
- 단어 추가 버튼 너비를 콘텐츠 크기에 맞게 조정하고 가운데 정렬
- 예문 입력창은 단독 행에 유지

#### 검색창 및 테이블 정렬
- 검색창 가로 폭을 테이블과 동일하게 맞춤
- 검색창 주변 여백 및 정렬 구조 개선

#### 수정 팝업 개선

#### 표 구조 개선
- '관리' 열의 가로 너비를 버튼 사이즈에 딱 맞게 조정
- 표 전반의 시각 균형을 조정하여 정렬 및 너비 일관성 확보

---

### 릴리즈 예정 태그
- `v2.3`
